### PR TITLE
Add a 'make lint' command to Travis runs using flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 - make deps
 script:
 - make fmt
+- make lint
 - git diff --exit-code
 - make test
 - make docker-build

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 .PHONY: docker-build
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ deps:
 fmt:
 	yapf -vv -i $(shell git ls-files '*.py')
 
+.PHONY: lint
+lint:
+	flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+
 .PHONY: docker-build
 docker-build:
 	$(DOCKER) build -t="$(DOCKER_TAG)" .

--- a/gesund.py
+++ b/gesund.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 import time
 
+import redis
+
 from threading import Thread
 from wsgiref.simple_server import make_server
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 redis>=2.10
 
 codecov>=2.0
+flake8>=3.5.0
 pytest-cov>=2.0
 pytest>=3.4
 yapf>=0.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 redis>=2.10
 
 codecov>=2.0
-flake8>=3.5.0
+flake8>=3.7.8
 pytest-cov>=2.0
 pytest>=3.4
 yapf>=0.22


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree